### PR TITLE
Add updating apt cache and installing gnupg2

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,14 @@
   fail: msg="You must set root password (percona_server_root_password)"
   when: percona_server_root_password is not defined
 
+# https://www.percona.com/doc/percona-server/5.7/installation/apt_repo.html#installing-percona-server-from-percona-apt-repository
+- name: Install percona-release dependencies
+  apt:
+    name: gnupg2
+    state: present
+    update_cache: yes
+    cache_valid_time: 300
+
 - name: Install Percona packages
   apt:
     deb: https://repo.percona.com/apt/percona-release_latest.{{ ansible_distribution_release }}_all.deb


### PR DESCRIPTION
For Debian 9, before task `Install Percona packages` should at least do this:
```
- apt:
    update_cache: yes
```

Otherwise, will get an error:
```
  "stderr_lines": [
    "E: Failed to fetch http://security.debian.org/debian-security/pool/updates/main/c/curl/libcurl3_7.52.1-5+deb9u12_amd64.deb  404  Not Found [IP: 199.232.18.132 80]",
    "E: Failed to fetch http://security.debian.org/debian-security/pool/updates/main/c/curl/curl_7.52.1-5+deb9u12_amd64.deb  404  Not Found [IP: 199.232.18.132 80]",
    "E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?"
  ],
```

For Debian 11, before task `Install Percona packages` should do this:
```
- apt:
    name: gnupg2
    state: present
    update_cache: yes
```

Otherwise, will get an error:
```
  "stderr_lines": [
    "dpkg: error processing package percona-release (--install):",
    " installed percona-release package post-installation script subprocess returned error exit status 255",
    "Errors were encountered while processing:",
    " percona-release"
  ],
```